### PR TITLE
fix: stop shrink the top section

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -114,7 +114,8 @@ export function App() {
         gap={3}
         columns={['minmax(0, 1fr)', 'minmax(0, 1fr)']}
         padding={[3, 4]}
-        paddingTop={5}>
+        paddingTop={5}
+        sx={{ minWidth: '100%' }}>
         <Centered>
           <PageHeading>Muminst</PageHeading>
         </Centered>


### PR DESCRIPTION
- Tweaks styles to not shrink the top section when the results items is empty.